### PR TITLE
fixes #185

### DIFF
--- a/custom_shortcuts/custom_shortcuts.py
+++ b/custom_shortcuts/custom_shortcuts.py
@@ -196,7 +196,6 @@ def cs_editor_setupShortcuts(self):
     for row in cuts:
         if len(row) == 2:
             keys, fn = row
-            fn = self._addFocusCheck(fn)
         else:
             keys, fn, _ = row
         scut = QShortcut(QKeySequence(keys), self.widget, activated=fn)


### PR DESCRIPTION
Hi, this PR fixes #185. It has been thoroughly tested, and the removal of this check doesn't cause any issues whatsoever!

It is my understanding that since the focusTrap was implemented, this check doesn't serve any purpose anymore. But the check does indeed break this add-on because it doesn't reflect the focusTrap's logic.

Once we click outside of a field, the focusTrap prevents the field from losing focus. But the check expects this behaviour, and is so never reset.